### PR TITLE
Add rock for net-istio-controller

### DIFF
--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -1,0 +1,53 @@
+# From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12
+name: net-istio-controller
+base: ubuntu@22.04
+version: v1.12.3
+summary: An image for Knative's net-istio-controller
+description: |
+  An image for Knative's net-istio-controller
+license: Apache-2.0
+entrypoint-service: net-istio-controller
+run-user: _daemon_
+
+platforms:
+  amd64:
+
+services:
+  net-istio-controller:
+    override: replace
+    command: "/ko-app/controller [ ]"
+    startup: enabled
+    user: ubuntu
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  net-istio-controller:
+    plugin: go
+    build-snaps:
+      - go/1.21/stable
+    source: https://github.com/knative-extensions/net-istio.git
+    source-tag: release-1.12
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      cd cmd/controller
+      mkdir $CRAFT_PART_INSTALL/ko-app
+      go build -o $CRAFT_PART_INSTALL/ko-app/controller -a .
+  
+  non-root-user:
+    plugin: nil
+    after: [ net-istio-controller ]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
+    override-prime: |
+      craftctl default

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -33,7 +33,7 @@ parts:
     build-snaps:
       - go/1.21/stable
     source: https://github.com/knative-extensions/net-istio.git
-    source-tag: release-1.12
+    source-tag: knative-v1.12.3
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -58,6 +58,11 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+    stage-packages:
+      # Install the packages existing in the base for the upstream image
+      - ca-certificates
+      - netbase
+      - tzdata
     override-build: |
       cd cmd/controller
       mkdir $CRAFT_PART_INSTALL/ko-app

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -1,7 +1,7 @@
 # From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12/cmd/controller
 name: net-istio-controller
 base: ubuntu@22.04
-version: v1.12.3
+version: 1.12.3
 summary: An image for Knative's net-istio controller
 description: |
   An image for Knative's net-istio controller

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -50,21 +50,6 @@ parts:
       # Install the packages existing in the base for the upstream image
       - netbase
       - tzdata
-    build-snaps:
-      - go/1.21/stable
-    source: https://github.com/knative-extensions/net-istio.git
-    source-type: git
-    source-tag: knative-v1.12.3
-    build-environment:
-      - CGO_ENABLED: 0
-      - GOOS: linux
-    overlay-packages:
-      # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
-      - ca-certificates
-    stage-packages:
-      # Install the packages existing in the base for the upstream image
-      - netbase
-      - tzdata
     override-build: |
       cd cmd/controller
       mkdir $CRAFT_PART_INSTALL/ko-app

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -49,5 +49,3 @@ parts:
       # Create a user in the $CRAFT_OVERLAY chroot
       groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
       useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
-    override-prime: |
-      craftctl default

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -58,6 +58,9 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+    overlay-packages:
+      # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
+      - ca-certificates
     stage-packages:
       # Install the packages existing in the base for the upstream image
       - netbase

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -13,7 +13,9 @@ platforms:
   amd64:
 
 environment:
+  # Environment variables that are set in the base image
   KO_DATA_PATH: "/var/run/ko"
+  SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
     
 services:
   net-istio-controller:
@@ -41,6 +43,9 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+    overlay-packages:
+      # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
+      - ca-certificates
     stage-packages:
       # Install the packages existing in the base for the upstream image
       - netbase

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -53,6 +53,7 @@ parts:
     build-snaps:
       - go/1.21/stable
     source: https://github.com/knative-extensions/net-istio.git
+    source-type: git
     source-tag: knative-v1.12.3
     build-environment:
       - CGO_ENABLED: 0

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -51,7 +51,7 @@ parts:
       go build -o $CRAFT_PART_INSTALL/ko-app/controller -a .
 
       # Copy the files from the ko-data directory to the install directory
-      mkdir -p $CRAFT_PART_INSTALL/var/run/kodata
+      mkdir -p $CRAFT_PART_INSTALL/var/run/ko
       cp -r $CRAFT_PART_SRC/cmd/controller/kodata/. $CRAFT_PART_INSTALL/var/run/ko
   
   non-root-user:

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -50,6 +50,13 @@ parts:
       # Install the packages existing in the base for the upstream image
       - netbase
       - tzdata
+    build-snaps:
+      - go/1.21/stable
+    source: https://github.com/knative-extensions/net-istio.git
+    source-tag: release-1.12
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
     override-build: |
       cd cmd/controller
       mkdir $CRAFT_PART_INSTALL/ko-app

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -2,9 +2,9 @@
 name: net-istio-controller
 base: ubuntu@22.04
 version: v1.12.3
-summary: An image for Knative's net-istio-controller
+summary: An image for Knative's net-istio controller
 description: |
-  An image for Knative's net-istio-controller
+  An image for Knative's net-istio controller
 license: Apache-2.0
 entrypoint-service: net-istio-controller
 run-user: _daemon_

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -60,7 +60,6 @@ parts:
       - GOOS: linux
     stage-packages:
       # Install the packages existing in the base for the upstream image
-      - ca-certificates
       - netbase
       - tzdata
     override-build: |

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -12,6 +12,9 @@ run-user: _daemon_
 platforms:
   amd64:
 
+environment:
+  KO_DATA_PATH: "/var/run/ko"
+    
 services:
   net-istio-controller:
     override: replace
@@ -38,10 +41,19 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+    stage-packages:
+      # Install the packages existing in the base for the upstream image
+      - ca-certificates
+      - netbase
+      - tzdata
     override-build: |
       cd cmd/controller
       mkdir $CRAFT_PART_INSTALL/ko-app
       go build -o $CRAFT_PART_INSTALL/ko-app/controller -a .
+
+      # Copy the files from the ko-data directory to the install directory
+      mkdir -p $CRAFT_PART_INSTALL/var/run/kodata
+      cp -r $CRAFT_PART_SRC/cmd/controller/kodata/. $CRAFT_PART_INSTALL/var/run/ko
   
   non-root-user:
     plugin: nil

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -1,4 +1,4 @@
-# From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12
+# From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12/cmd/controller
 name: net-istio-controller
 base: ubuntu@22.04
 version: v1.12.3

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -35,17 +35,17 @@ parts:
 
   net-istio-controller:
     plugin: go
-    build-snaps:
-      - go/1.21/stable
     source: https://github.com/knative-extensions/net-istio.git
     source-type: git
     source-tag: knative-v1.12.3
-    build-environment:
-      - CGO_ENABLED: 0
-      - GOOS: linux
     overlay-packages:
       # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
       - ca-certificates
+    build-snaps:
+      - go/1.21/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
     stage-packages:
       # Install the packages existing in the base for the upstream image
       - netbase

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -33,6 +33,7 @@ parts:
     build-snaps:
       - go/1.21/stable
     source: https://github.com/knative-extensions/net-istio.git
+    source-type: git
     source-tag: knative-v1.12.3
     build-environment:
       - CGO_ENABLED: 0

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -43,7 +43,6 @@ parts:
       - GOOS: linux
     stage-packages:
       # Install the packages existing in the base for the upstream image
-      - ca-certificates
       - netbase
       - tzdata
     override-build: |

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -53,7 +53,7 @@ parts:
     build-snaps:
       - go/1.21/stable
     source: https://github.com/knative-extensions/net-istio.git
-    source-tag: release-1.12
+    source-tag: knative-v1.12.3
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux

--- a/net-istio-controller/tests/test_rock.py
+++ b/net-istio-controller/tests/test_rock.py
@@ -43,3 +43,17 @@ def test_rock():
         ],
         check=True,
     )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /etc/ssl/certs/ca-certificates.crt",
+        ],
+        check=True,
+    )

--- a/net-istio-controller/tests/test_rock.py
+++ b/net-istio-controller/tests/test_rock.py
@@ -1,49 +1,40 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-#
 
-from pathlib import Path
-
-import os
-import logging
-import random
 import pytest
-import string
 import subprocess
-import yaml
 
 from charmed_kubeflow_chisme.rock import CheckRock
 
 
-@pytest.fixture()
-def rock_test_env(tmpdir):
-    """Yields a temporary directory and random docker container name, then cleans them up after."""
-    container_name = "".join(
-        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
-    )
-    yield tmpdir, container_name
-
-    try:
-        subprocess.run(["docker", "rm", container_name])
-    except Exception:
-        pass
-    # tmpdir fixture we use here should clean up the other files for us
-
-
 @pytest.mark.abort_on_fail
-def test_rock(rock_test_env):
+def test_rock():
     """Test rock."""
-    temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
     rock_image = check_rock.get_name()
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
+    # assert the rock contains the expected files
     subprocess.run(
         [
             "docker",
             "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
             "--entrypoint",
             "/bin/bash",
             LOCAL_ROCK_IMAGE,

--- a/net-istio-controller/tests/test_rock.py
+++ b/net-istio-controller/tests/test_rock.py
@@ -25,20 +25,6 @@ def test_rock():
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /third_party",
-        ],
-        check=True,
-    )
-
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
             "ls -la /ko-app/controller",
         ],
         check=True,

--- a/net-istio-controller/tests/test_rock.py
+++ b/net-istio-controller/tests/test_rock.py
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /ko-app/controller",
+        ],
+        check=True,
+    )

--- a/net-istio-controller/tests/test_rock.py
+++ b/net-istio-controller/tests/test_rock.py
@@ -25,6 +25,20 @@ def test_rock():
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
+            "ls -la /var/run/ko",
+        ],
+        check=True,
+    )
+    
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
             "ls -la /ko-app/controller",
         ],
         check=True,

--- a/net-istio-controller/tox.ini
+++ b/net-istio-controller/tox.ini
@@ -1,0 +1,51 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
Closes https://github.com/canonical/knative-operators/issues/238

This rock is based on the image found here: https://console.cloud.google.com/gcr/images/knative-releases/global/knative.dev/net-istio/cmd/controller

To check that everything is as expected:
```
# Clone the repository and checkout to this branch, then cd to the proper subdirectory
cd net-istio-controller

# Build the rock
tox -e pack

# Export to docker
tox -e export-to-docker

# Sanity tests
tox -e sanity

# Compare output with the upstream image

docker run gcr.io/knative-releases/knative.dev/net-istio/cmd/controller:v1.12.3
## Sample output
## Output
2024/11/12 11:27:01 Error building kubeconfig: failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable

docker run net-istio-webhook:v1.12.3
# Get the ID of the container
docker ps
# Run bash into it
docker exec -ti <container_id> bash
# Execute the service command manually
/ko-data/controller
## Sample output
# Output
2024/11/12 11:29:29 Error building kubeconfig: failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable