### PR TITLE
feat: add `knative-webhook` rock

### DIFF
--- a/knative-webhook/rockcraft.yaml
+++ b/knative-webhook/rockcraft.yaml
@@ -1,0 +1,70 @@
+name: knative-webhook
+summary: Knative webhook
+description: "Knative webhook"
+version: "1.12.4"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+    amd64:
+run-user: _daemon_
+
+environment:
+  # Required due to the go codebase relying on the OS Env being set
+  # See https://github.com/knative/operator/blob/knative-v1.12.4/pkg/reconciler/common/releases.go#L36
+  KO_DATA_PATH: "/var/run/ko"
+  # env identifies where to locate the SSL certificate file
+  SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
+
+services:
+  knative-operator-webhook:
+    override: replace
+    summary: "Knative webhook service"
+    startup: enabled
+    command: "/ko-app/webhook"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  webhook:
+    plugin: go
+    source: https://github.com/knative/operator
+    source-type: git
+    source-tag: knative-v1.12.4
+    overlay-packages:
+    # Install ca-certificates found in the base image
+    # reference: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md?plain=1#L9.
+    # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
+      - ca-certificates
+    build-snaps:
+      - go/1.19/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    stage-packages:
+    # Install packages existing in the base for the upstream image.
+    # Base image is set upstream in https://github.com/knative/operator/blob/knative-v1.12.4/.ko.yaml#L1.
+    # Packages existing in the base image are documented
+    # in https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md#image-contents.
+      - netbase
+      - tzdata
+    override-build: |
+
+      go mod download
+
+      # Build
+      go build -a -o webhook ./cmd/webhook
+
+      # Copy the files from the ko-data directory to the install directory
+      mkdir -p $CRAFT_PART_INSTALL/var/run/ko
+      # cp with `-L` to copy the linked file rather than the symlink.
+      cp -L -r $CRAFT_PART_SRC/cmd/webhook/kodata/. $CRAFT_PART_INSTALL/var/run/ko
+
+      # Copy the go binary to the install directory
+      mkdir $CRAFT_PART_INSTALL/ko-app
+      cp -r webhook $CRAFT_PART_INSTALL/ko-app/webhook

--- a/knative-webhook/rockcraft.yaml
+++ b/knative-webhook/rockcraft.yaml
@@ -1,3 +1,4 @@
+# Based on ko image: https://github.com/knative/operator/tree/knative-v1.12.4/cmd/webhook
 name: knative-webhook
 summary: Knative webhook
 description: "Knative webhook"

--- a/knative-webhook/tests/test_rock.py
+++ b/knative-webhook/tests/test_rock.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /var/run/ko",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /ko-app/webhook",
+        ],
+        check=True,
+    )
+
+    # check for SSL cert file
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /etc/ssl/certs/ca-certificates.crt",
+        ],
+        check=True,
+    )

--- a/knative-webhook/tox.ini
+++ b/knative-webhook/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    rockcraft
+    bash
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    charmed-kubeflow-chisme
+    pytest
+    pytest-operator
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here


### PR DESCRIPTION
Closes https://github.com/canonical/bundle-kubeflow/issues/1138

Rock is based on the upstream ko image by `knative`: https://github.com/knative/operator/tree/knative-v1.12.4/cmd/webhook

To compare the rock I used the upstream docker tag `knative-v1.12.4`, that is the version we are using in knative in kubeflow 1.9 [charm](https://github.com/canonical/knative-operators/blob/track/1.12/charms/knative-operator/metadata.yaml#L31).

## Testing
### Compare to the upstream image
* Run the upstream image with `docker run`:
```
docker run gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.4
panic: The environment variable "WEBHOOK_NAME" is not set.
This should be unique for the webhooks in a namespace
If this is a process running on Kubernetes, then initialize this variable via:
  env:
  - name: WEBHOOK_NAME
    value: webhook


goroutine 1 [running]:
knative.dev/pkg/webhook.NameFromEnv()
	knative.dev/pkg@v0.0.0-20231103063133-e287426d1833/webhook/env.go:56 +0x7b
main.main()
	knative.dev/operator/cmd/webhook/main.go:37 +0x6f
```
* Download the Rock built from the PR Checks Summary
*  Import the rock into your local docker registry using `skopeo`:
```
rockcraft.skopeo --insecure-policy copy oci-archive:knative-webhook docker-daemon:knative-webhook:test-rock
```
* Run the Rock with `docker run` and `exec` with the pebble service command:
```
docker run docker.io/library/knative-webhook:1.12.4 exec /ko-app/webhook
```
Expected output:
```
panic: The environment variable "WEBHOOK_NAME" is not set.
This should be unique for the webhooks in a namespace
If this is a process running on Kubernetes, then initialize this variable via:
  env:
  - name: WEBHOOK_NAME
    value: webhook


goroutine 1 [running]:
knative.dev/pkg/webhook.NameFromEnv()
	/root/parts/webhook/build/vendor/knative.dev/pkg/webhook/env.go:56 +0x88
main.main()
	/root/parts/webhook/build/cmd/webhook/main.go:37 +0x77
```
Note that the `panic` is expected due to the absence of the `WEBHOOK_NAME` env, that is set by the pebble layer in [the charm](https://github.com/canonical/knative-operators/blob/main/charms/knative-operator/src/charm.py#L198)

### Testing with knative-operator charm
Prerequisite: setup juju+microk8s, see the [tutorial](https://charmed-kubeflow.io/docs/get-started) for instructions.
1. Download the Rock built from the PR Checks Summary
2. Import the rock into your local docker registry using `skopeo`:
```
rockcraft.skopeo --insecure-policy copy oci-archive:knative-webhook docker-daemon:knative-webhook:test-rock
```
3. Import the rock into microk8s container registry
```
docker save knative-webhook:test-rock-o knative-webhook-rock.tar
microk8s ctr image import knative-webhook-rock.tar
```
4. Replace the upstream image in the metadata.yaml with the local Rock. Diff:
```
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.4
+    upstream-source: docker.io/library/knative-webhook:test-rock
```
5. Run the knative bundle integration tests:
```
tox -vve integration -- --model knative-test --keep-models
```

Expected output:
```
======================================================= 7 passed in 154.18s (0:02:34) ========================================================
integration: 156114 I exit 0 (155.70 seconds) /home/nohaihab/repos/knative-operators> pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native --model knative-test --keep-models tests/test_bundle.py pid=3461570 [tox/execute/api.py:286]
  integration: OK (155.80=setup[0.10]+cmd[155.70] seconds)
  congratulations :) (155.92 seconds)
```