### PR TITLE
Fix version string in net-istio-webhook

### DIFF
--- a/net-istio-webhook/rockcraft.yaml
+++ b/net-istio-webhook/rockcraft.yaml
@@ -1,7 +1,7 @@
 # From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12
 name: net-istio-webhook
 base: ubuntu@22.04
-version: v1.12.3
+version: 1.12.3
 summary: An image for Knative's net-istio-webhook
 description: |
   An image for Knative's net-istio-webhook


### PR DESCRIPTION
Fixes the version string in net-istio-webhook to not include the 'v'