### PR TITLE
chore: bump operator rock 1.12.4 > 1.16.0

### DIFF
--- a/knative-operator/rockcraft.yaml
+++ b/knative-operator/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: knative-operator
 summary: Knative operator
 description: "Knative operator"
-version: "1.12.4"
+version: "1.16.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -35,14 +35,14 @@ parts:
     plugin: go
     source: https://github.com/knative/operator
     source-type: git
-    source-tag: knative-v1.12.4
+    source-tag: knative-v1.16.0
     overlay-packages:
     # Install ca-certificates found in the base image
     # reference: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md?plain=1#L9.
     # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
       - ca-certificates
     build-snaps:
-      - go/1.19/stable
+      - go/1.22/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux

--- a/knative-operator/rockcraft.yaml
+++ b/knative-operator/rockcraft.yaml
@@ -1,3 +1,4 @@
+# Based on ko image: https://github.com/knative/operator/tree/knative-v1.16.0/cmd/operator
 name: knative-operator
 summary: Knative operator
 description: "Knative operator"
@@ -10,7 +11,7 @@ run-user: _daemon_
 
 environment:
   # Required due to the go codebase relying on the OS Env being set
-  # See https://github.com/knative/operator/blob/knative-v1.12.4/pkg/reconciler/common/releases.go#L36
+  # See https://github.com/knative/operator/blob/knative-v1.16.0/pkg/reconciler/common/releases.go#L36
   KO_DATA_PATH: "/var/run/ko"
   # env identifies where to locate the SSL certificate file
   SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
@@ -48,7 +49,7 @@ parts:
       - GOOS: linux
     stage-packages:
     # Install packages existing in the base for the upstream image.
-    # Base image is set upstream in https://github.com/knative/operator/blob/knative-v1.12.4/.ko.yaml#L1.
+    # Base image is set upstream in https://github.com/knative/operator/blob/knative-v1.16.0/.ko.yaml#L1.
     # Packages existing in the base image are documented
     # in https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md#image-contents.
       - netbase


### PR DESCRIPTION
Bump the `knative-operator` rock from `1.12.4` to `1.16.0` in preparation for CKF 1.10