### PR TITLE
Patch upstream code to set readOnlyRootFilesystem to false

### DIFF
--- a/knative-operator/rockcraft.yaml
+++ b/knative-operator/rockcraft.yaml
@@ -55,6 +55,14 @@ parts:
       - netbase
       - tzdata
     override-build: |
+      # patch readOnlyRootFilesystem in manifests applied by the operator
+      # More details in https://github.com/canonical/knative-operators/issues/291
+      # Remove once pebble won't need to always write some state to disk
+      # https://github.com/canonical/pebble/issues/462
+      find . -type f \
+          -exec sed -i \
+          "s#readOnlyRootFilesystem: true#readOnlyRootFilesystem: false#g" \
+          {} +
 
       go mod download
 
@@ -63,7 +71,7 @@ parts:
 
       # Copy the files from the ko-data directory to the install directory
       mkdir -p $CRAFT_PART_INSTALL/var/run/ko
-      cp -r $CRAFT_PART_SRC/cmd/operator/kodata/. $CRAFT_PART_INSTALL/var/run/ko
+      cp -r cmd/operator/kodata/. $CRAFT_PART_INSTALL/var/run/ko
 
       # Copy the go binary to the install directory
       mkdir $CRAFT_PART_INSTALL/ko-app

--- a/knative-operator/tests/test_rock.py
+++ b/knative-operator/tests/test_rock.py
@@ -1,9 +1,9 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 import subprocess
 
+import pytest
 from charmed_kubeflow_chisme.rock import CheckRock
 
 
@@ -55,6 +55,26 @@ def test_rock():
             LOCAL_ROCK_IMAGE,
             "-c",
             "ls -la /etc/ssl/certs/ca-certificates.crt",
+        ],
+        check=True,
+    )
+
+    # ensure no "readOnlyRootFilesystem: true" in the manifests
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            # A. if grep found the string (test should fail) then grep returns 0.
+            # But we want the test to fail, so we do && to return exit code 1
+            # B. if grep did NOT find the string (test should succecced) then grep returns 1.
+            # But we want the test to succeed, so in this case the && is not calculated,
+            # since we have a failing exit code and || exit 0 happens
+            'grep -ri "readOnlyRootFilesystem: true" /var/run/ko && exit 1 || exit 0',
         ],
         check=True,
     )


### PR DESCRIPTION
Closes https://github.com/canonical/knative-operators/issues/291

To unblock our integration of our rocks, until pebble will can handle read-only filesystems. 

## Changes
1. Update all code and files to have `readOnlyRootFilesystem: false`
2. Add unit test to ensure the manifests in the final rock comply with the above assumption