### PR TITLE
chore: upgrade migrate to 1.16

### DIFF
--- a/migrate/rockcraft.yaml
+++ b/migrate/rockcraft.yaml
@@ -1,7 +1,7 @@
 # From (ko image): https://github.com/knative/pkg/blob/release-1.16/apiextensions/storageversion/cmd/migrate/main.go
 name: migrate
 base: ubuntu@22.04
-version: 1.16.1
+version: 1.16.0
 summary: An image for Knative's migrate
 description: |
   An image for Knative's migrate

--- a/migrate/rockcraft.yaml
+++ b/migrate/rockcraft.yaml
@@ -1,7 +1,7 @@
-# From (ko image): https://github.com/knative/pkg/blob/release-1.12/apiextensions/storageversion/cmd/migrate/main.go
+# From (ko image): https://github.com/knative/pkg/blob/release-1.16/apiextensions/storageversion/cmd/migrate/main.go
 name: migrate
 base: ubuntu@22.04
-version: 1.12.4
+version: 1.16.1
 summary: An image for Knative's migrate
 description: |
   An image for Knative's migrate
@@ -36,12 +36,12 @@ parts:
     plugin: go
     source: https://github.com/knative/pkg.git
     source-type: git
-    source-branch: release-1.12
+    source-branch: release-1.16
     overlay-packages:
       # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
       - ca-certificates
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable # from https://github.com/knative/pkg/blob/release-1.16/go.mod#L3
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
* Upgrade migrate rock to 1.16.
* Add a comment for the go version source to facilitate next upgrades.

Close https://warthogs.atlassian.net/browse/KF-6930

#### Upgrade
In order to do the upgrade I went through the [spec](https://docs.google.com/document/d/1l_CrR_5U6NmDXpcoH2hkhVuoDzdpwFto6EwsylQ5vRw/edit?tab=t.0) in order to figure out what points I should check and:
* checked packages in base image `cgr.dev/chainguard/static` but didn't spot anything new
* Checked go version
* Checked code for changes

Also regarding the patch version, I used 1.16.0 since the last change in the branch was around October, when 1.16.0 was released.
 
#### Testing
Built and ran the image and noticed the same logs as the previous version of the rock (and the upstream image)
```
2025-02-13T16:13:21.954Z [migrate] {"severity":"EMERGENCY","timestamp":"2025-02-13T16:13:21.95451396Z","logger":"storage-migrator","caller":"migrate/main.go:52","message":"failed to get kubeconfig failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","commit":"9b9d535","stacktrace":"main.main\n\t/root/parts/migrate/build/apiextensions/storageversion/cmd/migrate/main.go:52\nruntime.main\n\t/snap/go/10828/src/runtime/proc.go:271"}
``` 