### PR TITLE
chore: upgrade net-istio-controller to 1.16

### DIFF
--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -1,7 +1,9 @@
-# From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12/cmd/controller
+# From (ko image): https://github.com/knative-extensions/net-istio/tree/knative-v1.16.0/cmd/controller
+# Currently based on gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:e70bc675f97778da144157f125b3001124ba7a5903b85dab9e77776352fea1c7
+# See https://github.com/canonical/knative-operators/blob/main/tools/get-images.sh#L36-L42
 name: net-istio-controller
 base: ubuntu@22.04
-version: 1.12.3
+version: 1.16.0
 summary: An image for Knative's net-istio controller
 description: |
   An image for Knative's net-istio controller
@@ -36,24 +38,21 @@ parts:
     plugin: go
     source: https://github.com/knative-extensions/net-istio.git
     source-type: git
-    source-tag: knative-v1.12.3
+    source-tag: knative-v1.16.0
     overlay-packages:
       # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
       - ca-certificates
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable # from https://github.com/knative-extensions/net-istio/blob/main/go.mod#L3
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
     stage-packages:
       # Install the packages existing in the base for the upstream image
-      - netbase
+      # Base upstream image defined at https://github.com/knative-extensions/net-istio/blob/main/.ko.yaml#L1
+      # Packages https://github.com/wolfi-dev/tools/blob/main/images/static/configs/alpine.apko.yaml#L3
       - tzdata
     override-build: |
       cd cmd/controller
       mkdir $CRAFT_PART_INSTALL/ko-app
       go build -o $CRAFT_PART_INSTALL/ko-app/controller -a .
-
-      # Copy the files from the ko-data directory to the install directory
-      mkdir -p $CRAFT_PART_INSTALL/var/run/ko
-      cp -r $CRAFT_PART_SRC/cmd/controller/kodata/. $CRAFT_PART_INSTALL/var/run/ko

--- a/net-istio-controller/rockcraft.yaml
+++ b/net-istio-controller/rockcraft.yaml
@@ -43,7 +43,7 @@ parts:
       # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
       - ca-certificates
     build-snaps:
-      - go/1.22/stable # from https://github.com/knative-extensions/net-istio/blob/main/go.mod#L3
+      - go/1.22/stable  # from https://github.com/knative-extensions/net-istio/blob/main/go.mod#L3
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux

--- a/net-istio-controller/tests/test_rock.py
+++ b/net-istio-controller/tests/test_rock.py
@@ -15,21 +15,6 @@ def test_rock():
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # assert the rock contains the expected files
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /var/run/ko",
-        ],
-        check=True,
-    )
-    
     subprocess.run(
         [
             "docker",


### PR DESCRIPTION
* Upgrade source-tags
* Upgrade go versions
* Update packages according to new base image
* Remove copying files that are removed from upstream code
* Add comments to:
   - outline which specific upstream image this rock corresponds to
   - outline how to figure out which upstream image this rock should be updated to each time
   - outline where base image is define in upstream
   - outline where base image packages are defined in upstream

Fix https://warthogs.atlassian.net/browse/KF-6931

#### Upgrade details and process
After looking at [ko images spec](https://docs.google.com/document/d/1l_CrR_5U6NmDXpcoH2hkhVuoDzdpwFto6EwsylQ5vRw/edit?tab=t.0), this is a summary of the changes and the process I followed:
* Changed base image from [distroless/static:nonroot](https://github.com/knative-extensions/net-istio/blob/release-1.12/.ko.yaml#L2) to [wolfi-dev/static:alpine](https://github.com/knative-extensions/net-istio/blob/release-1.16/.ko.yaml). 
* Bumped go version to 1.22 according to https://github.com/knative-extensions/net-istio/blob/release-1.16/go.mod#L3
* Figured out the exact image (in order to use `dive`) by following this https://github.com/canonical/knative-operators/blob/312c3d0c06e0c44e0ba3052956c1181832775060/tools/get-images.sh#L36-L42 which is `gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:e70bc675f97778da144157f125b3001124ba7a5903b85dab9e77776352fea1c7` (added that as a comment). Here is where it gets tricky, using `dive` tool I didn't find any packages installed neither the base image nor the `cmd/controller` (screenshots from the `cmd/controller` - one with `etc` collapsed so we can view the whole structure)
![Pasted image 20250214105823](https://github.com/user-attachments/assets/d279948c-e424-402a-84e0-536da4c84bf0)
![Pasted image 20250214105859](https://github.com/user-attachments/assets/efae8f74-70af-45b1-8c7d-d37e2bbc46e0)
However, looking into the base image code, I noticed:
     * Looking at image's registry https://github.com/wolfi-dev/tools/pkgs/container/static#static 
     * Looking its code, there is tzdata https://github.com/wolfi-dev/tools/blob/main/images/static/configs/alpine.apko.yaml#L3. That's why I kept only this.
* File structure changes https://github.com/knative-extensions/net-istio/compare/release-1.12...release-1.16#diff-91da2533878043c0f020afcae116bd4128254dce1fdb277cf48aa15e402bfe0b (removed kodata copy)


#### Testing
```
$ docker run --rm gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:e70bc675f97778da144157f125b3001124ba7a5903b85dab9e77776352fea1c7    
2025/02/14 09:59:53 Error building kubeconfig: failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
$ docker run --rm $IMG                                                                           
2025-02-14T09:58:36.565Z [pebble] Started daemon.
2025-02-14T09:58:36.573Z [pebble] POST /v1/services 4.522872ms 202
2025-02-14T09:58:36.576Z [pebble] Service "net-istio-controller" starting: /ko-app/controller
2025-02-14T09:58:36.601Z [pebble] Service "net-istio-controller" stopped unexpectedly with code 1
2025-02-14T09:58:36.601Z [pebble] Service "net-istio-controller" on-failure action is "restart", waiting ~500ms before restart (backoff 1)
2025-02-14T09:58:36.605Z [pebble] Change 1 task (Start service "net-istio-controller") failed: service start attempt: exited quickly with code 1, will restart
2025-02-14T09:58:36.612Z [pebble] GET /v1/changes/1/wait 39.264622ms 200
2025-02-14T09:58:36.613Z [pebble] Started default services with change 1.
2025-02-14T09:58:37.104Z [pebble] Service "net-istio-controller" starting: /ko-app/controller
2025-02-14T09:58:37.128Z [pebble] Service "net-istio-controller" stopped unexpectedly with code 1
2025-02-14T09:58:37.128Z [pebble] Service "net-istio-controller" on-failure action is "restart", waiting ~1s before restart (backoff 2)
$ docker ps -aq                                                  
670d572a7273
$ docker exec -it 670d572a7273 /bin/bash            
_daemon_@670d572a7273:/$ pebble logs
2025-02-14T09:58:36.599Z [net-istio-controller] 2025/02/14 09:58:36 Error building kubeconfig: failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```