### PR TITLE
chore: upgrade net-istio-webhook to 1.16

### DIFF
--- a/net-istio-webhook/rockcraft.yaml
+++ b/net-istio-webhook/rockcraft.yaml
@@ -1,7 +1,9 @@
-# From (ko image): https://github.com/knative-extensions/net-istio/tree/release-1.12
+# From (ko image): https://github.com/knative-extensions/net-istio/tree/knative-v1.16.0/cmd/webhook
+# Currently based on gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:7d76a6d42d139ed53aae3ca2dfd600b1c776eb85a17af64dd1b604176a4b132a
+# See https://github.com/canonical/knative-operators/blob/main/tools/get-images.sh#L36-L42
 name: net-istio-webhook
 base: ubuntu@22.04
-version: 1.12.3
+version: 1.16.0
 summary: An image for Knative's net-istio-webhook
 description: |
   An image for Knative's net-istio-webhook
@@ -11,6 +13,11 @@ run-user: _daemon_
 
 platforms:
   amd64:
+
+environment:
+  # Environment variables that are set in the base image
+  KO_DATA_PATH: "/var/run/ko"
+  SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
 
 services:
   net-istio-webhook:
@@ -30,12 +37,20 @@ parts:
   net-istio-webhook:
     plugin: go
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable  # from https://github.com/knative-extensions/net-istio/blob/main/go.mod#L3
     source: https://github.com/knative-extensions/net-istio.git
-    source-tag: release-1.12
+    source-tag: knative-v1.16.0
+    overlay-packages:
+      # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
+      - ca-certificates
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+    stage-packages:
+      # Install the packages existing in the base for the upstream image
+      # Base upstream image defined at https://github.com/knative-extensions/net-istio/blob/main/.ko.yaml#L1
+      # Packages https://github.com/wolfi-dev/tools/blob/main/images/static/configs/alpine.apko.yaml#L3
+      - tzdata
     override-build: |
       cd cmd/webhook
       mkdir $CRAFT_PART_INSTALL/ko-app


### PR DESCRIPTION
* Upgrade source-tags
* Upgrade go version
* Update packages according to new base image
* Add missing environment values
* Add missing overlay and stage-packages according to base image
* Add comments to mention:
   - which hash of the upstream image this rock corresponds to
   - how to figure out the hash of the upstream image this rock should be updated to each time
   - where the base image is defined in upstream
   - where the base image packages are defined in upstream

Fix https://warthogs.atlassian.net/browse/KF-6932

#### Upgrade details and process
Please see #26 for more details. Some references:
* https://github.com/knative-extensions/net-istio/blob/release-1.16/.ko.yaml
* https://github.com/knative-extensions/net-istio/blob/release-1.16/go.mod#L3

#### Testing
```
$ docker run --rm gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:7d76a6d42d139ed53aae3ca2dfd600b1c776eb85a17af64dd1b604176a4b132a                        
2025/02/14 15:01:07 Error building kubeconfig: failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2025-02-14T15:00:17.405Z [pebble] Started daemon.
2025-02-14T15:00:17.413Z [pebble] POST /v1/services 4.213701ms 202
2025-02-14T15:00:17.416Z [pebble] Service "net-istio-webhook" starting: /ko-app/webhook
2025-02-14T15:00:17.445Z [pebble] Service "net-istio-webhook" stopped unexpectedly with code 1
2025-02-14T15:00:17.445Z [pebble] Service "net-istio-webhook" on-failure action is "restart", waiting ~500ms before restart (backoff 1)
2025-02-14T15:00:17.448Z [pebble] Change 1 task (Start service "net-istio-webhook") failed: service start attempt: exited quickly with code 1, will restart
2025-02-14T15:00:17.457Z [pebble] GET /v1/changes/1/wait 43.072529ms 200
2025-02-14T15:00:17.457Z [pebble] Started default services with change 1.
2025-02-14T15:00:17.988Z [pebble] Service "net-istio-webhook" starting: /ko-app/webhook
2025-02-14T15:00:18.013Z [pebble] Service "net-istio-webhook" stopped unexpectedly with code 1
2025-02-14T15:00:18.013Z [pebble] Service "net-istio-webhook" on-failure action is "restart", waiting ~1s before restart (backoff 2)
...
$ docker ps -aq                                                                                                                                   
aa438d69714e
$ docker exec -it aa438d69714e /bin/bash            
_daemon_@aa438d69714e:/$ pebble logs
2025-02-14T15:00:17.443Z [net-istio-webhook] 2025/02/14 15:00:17 Error building kubeconfig: failed to create client config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```