### PR TITLE
Add `Knative Serving Autoscaler` rock and tests

### DIFF
--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on ko image: https://github.com/knative/serving/tree/knative-v1.12.4/cmd/autoscaler
-name: knative-autoscaler
+# Based on ko image: https://github.com/knative/serving/tree/knative-v1.16.0/cmd/autoscaler
+name: knative-serving-autoscaler
 summary: Knative Serving Autoscaler
 description: "Knative Serving Autoscaler"
-version: "1.12.4"
+version: "1.16.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -17,7 +17,7 @@ environment:
   SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
 
 services:
-  knative-autoscaler:
+  knative-serving-autoscaler:
     override: replace
     summary: "Knative Serving Autoscaler service"
     startup: enabled
@@ -36,7 +36,7 @@ parts:
     plugin: go
     source: https://github.com/knative/serving
     source-type: git
-    source-tag: knative-v1.12.4
+    source-tag: knative-v1.16.0
     overlay-packages:
     # Install ca-certificates found in the base image
     # reference: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md?plain=1#L9.
@@ -72,7 +72,7 @@ parts:
       # Copy the files from the ko-data directory to the install directory
       # The upstream dockerfile doesn't have ko-data
       mkdir -p $CRAFT_PART_INSTALL/var/run/ko
-      cp -r $CRAFT_PART_SRC/cmd/autoscaler/kodata/. $CRAFT_PART_INSTALL/var/run/ko
+      #cp -r $CRAFT_PART_SRC/cmd/autoscaler/kodata/. $CRAFT_PART_INSTALL/var/run/ko
 
       # Copy the go binary to the install directory
       mkdir $CRAFT_PART_INSTALL/ko-app

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -50,7 +50,7 @@ parts:
       - GOOS: linux
     stage-packages:
     # Install packages existing in the base for the upstream image.
-    # Base image is set upstream in https://github.com/knative/operator/blob/knative-v1.16.0/.ko.yaml#L1.
+    # Base image is set upstream in https://github.com/knative/serving/blob/knative-v1.16.0/.ko.yaml#L2.
     # Packages existing in the base image are documented
     # in https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md#image-contents.
       - netbase

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -60,7 +60,7 @@ parts:
       # Build
       go build -a -o autoscaler ./cmd/autoscaler
 
-      # Copy the files from the ko-data directory to the install directory
+      # Create directory for `KO_DATA_PATH` env
       mkdir -p $CRAFT_PART_INSTALL/var/run/ko
 
       # Copy the go binary to the install directory

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -1,0 +1,79 @@
+# Based on ko image: https://github.com/knative/serving/tree/knative-v1.12.4/cmd/autoscaler
+name: knative-autoscaler
+summary: Knative Serving Autoscaler
+description: "Knative Serving Autoscaler"
+version: "1.12.4"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+    amd64:
+run-user: _daemon_
+
+environment:
+  # Required due to the go codebase relying on the OS Env being set
+  # See https://github.com/knative/operator/blob/knative-v1.16.0/pkg/reconciler/common/releases.go#L36
+  KO_DATA_PATH: "/var/run/ko"
+  # env identifies where to locate the SSL certificate file
+  SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
+
+services:
+  knative-autoscaler:
+    override: replace
+    summary: "Knative Serving Autoscaler service"
+    startup: enabled
+    command: "/ko-app/autoscaler"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  autoscaler:
+    plugin: go
+    source: https://github.com/knative/serving
+    source-type: git
+    source-tag: knative-v1.12.4
+    overlay-packages:
+    # Install ca-certificates found in the base image
+    # reference: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md?plain=1#L9.
+    # Install in overlay instead of stage packages due to https://github.com/canonical/rockcraft/issues/334.
+      - ca-certificates
+    build-snaps:
+      - go/1.22/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    stage-packages:
+    # Install packages existing in the base for the upstream image.
+    # Base image is set upstream in https://github.com/knative/operator/blob/knative-v1.16.0/.ko.yaml#L1.
+    # Packages existing in the base image are documented
+    # in https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md#image-contents.
+      - netbase
+      - tzdata
+    override-build: |
+      # patch readOnlyRootFilesystem in manifests applied by the operator
+      # More details in https://github.com/canonical/knative-operators/issues/291
+      # Remove once pebble won't need to always write some state to disk
+      # https://github.com/canonical/pebble/issues/462
+      find . -type f \
+          -exec sed -i \
+          "s#readOnlyRootFilesystem: true#readOnlyRootFilesystem: false#g" \
+          {} +
+
+      go mod download
+
+      # Build
+      go build -a -o autoscaler ./cmd/autoscaler
+
+      # Copy the files from the ko-data directory to the install directory
+      # The upstream dockerfile doesn't have ko-data
+      mkdir -p $CRAFT_PART_INSTALL/var/run/ko
+      cp -r $CRAFT_PART_SRC/cmd/autoscaler/kodata/. $CRAFT_PART_INSTALL/var/run/ko
+
+      # Copy the go binary to the install directory
+      mkdir $CRAFT_PART_INSTALL/ko-app
+      cp -r autoscaler $CRAFT_PART_INSTALL/ko-app/autoscaler

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -70,7 +70,6 @@ parts:
       go build -a -o autoscaler ./cmd/autoscaler
 
       # Copy the files from the ko-data directory to the install directory
-      # The upstream dockerfile doesn't have ko-data
       mkdir -p $CRAFT_PART_INSTALL/var/run/ko
 
       # Copy the go binary to the install directory

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -11,8 +11,7 @@ platforms:
     amd64:
 
 environment:
-  # Required due to the go codebase relying on the OS Env being set
-  # See https://github.com/knative/operator/blob/knative-v1.16.0/pkg/reconciler/common/releases.go#L36
+  # env is set in upstream image, can be viewed with `docker inspect`
   KO_DATA_PATH: "/var/run/ko"
   # env identifies where to locate the SSL certificate file
   SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -5,9 +5,10 @@ description: "Knative Serving Autoscaler"
 version: "1.16.0"
 license: Apache-2.0
 base: ubuntu@22.04
+run-user: _daemon_
+
 platforms:
     amd64:
-run-user: _daemon_
 
 environment:
   # Required due to the go codebase relying on the OS Env being set
@@ -55,15 +56,6 @@ parts:
       - netbase
       - tzdata
     override-build: |
-      # patch readOnlyRootFilesystem in manifests applied by the operator
-      # More details in https://github.com/canonical/knative-operators/issues/291
-      # Remove once pebble won't need to always write some state to disk
-      # https://github.com/canonical/pebble/issues/462
-      find . -type f \
-          -exec sed -i \
-          "s#readOnlyRootFilesystem: true#readOnlyRootFilesystem: false#g" \
-          {} +
-
       go mod download
 
       # Build

--- a/knative-serving-autoscaler/rockcraft.yaml
+++ b/knative-serving-autoscaler/rockcraft.yaml
@@ -72,7 +72,6 @@ parts:
       # Copy the files from the ko-data directory to the install directory
       # The upstream dockerfile doesn't have ko-data
       mkdir -p $CRAFT_PART_INSTALL/var/run/ko
-      #cp -r $CRAFT_PART_SRC/cmd/autoscaler/kodata/. $CRAFT_PART_INSTALL/var/run/ko
 
       # Copy the go binary to the install directory
       mkdir $CRAFT_PART_INSTALL/ko-app

--- a/knative-serving-autoscaler/tests/test_rock.py
+++ b/knative-serving-autoscaler/tests/test_rock.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import pytest

--- a/knative-serving-autoscaler/tests/test_rock.py
+++ b/knative-serving-autoscaler/tests/test_rock.py
@@ -58,22 +58,3 @@ def test_rock():
         ],
         check=True,
     )
-    # ensure no "readOnlyRootFilesystem: true" in the manifests
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            # A. if grep found the string (test should fail) then grep returns 0.
-            # But we want the test to fail, so we do && to return exit code 1
-            # B. if grep did NOT find the string (test should succecced) then grep returns 1.
-            # But we want the test to succeed, so in this case the && is not calculated,
-            # since we have a failing exit code and || exit 0 happens
-            'grep -ri "readOnlyRootFilesystem: true" /var/run/ko && exit 1 || exit 0',
-        ],
-        check=True,
-    )

--- a/knative-serving-autoscaler/tests/test_rock.py
+++ b/knative-serving-autoscaler/tests/test_rock.py
@@ -1,0 +1,79 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /var/run/ko",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /ko-app/autoscaler",
+        ],
+        check=True,
+    )
+
+    # check for SSL cert file
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /etc/ssl/certs/ca-certificates.crt",
+        ],
+        check=True,
+    )
+    # ensure no "readOnlyRootFilesystem: true" in the manifests
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            # A. if grep found the string (test should fail) then grep returns 0.
+            # But we want the test to fail, so we do && to return exit code 1
+            # B. if grep did NOT find the string (test should succecced) then grep returns 1.
+            # But we want the test to succeed, so in this case the && is not calculated,
+            # since we have a failing exit code and || exit 0 happens
+            'grep -ri "readOnlyRootFilesystem: true" /var/run/ko && exit 1 || exit 0',
+        ],
+        check=True,
+    )

--- a/knative-serving-autoscaler/tox.ini
+++ b/knative-serving-autoscaler/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    rockcraft
+    bash
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    charmed-kubeflow-chisme
+    pytest
+    pytest-operator
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here

--- a/knative-serving-autoscaler/tox.ini
+++ b/knative-serving-autoscaler/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True


### PR DESCRIPTION
# Changes
Added rock for Knative Serving Autoscaler. See [source](https://github.com/knative/serving/tree/knative-v1.16.0/cmd/autoscaler)

# Files

- Add rockcraft.yaml
- Add tests
- Add tox.ini

# Testing
I uploaded rock to local microk8s. Then I activated it through `config.yaml` in knative-serving charm from [here](https://github.com/canonical/knative-operators) and then run  integration tests. 

Status of `juju status` after testing

```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.3    unsupported  14:39:26+02:00

App                   Version  Status  Scale  Charm             Channel       Rev  Address         Exposed  Message
istio-ingressgateway           active      1  istio-gateway     latest/edge  1378  10.152.183.83   no       
istio-pilot                    active      1  istio-pilot       latest/edge  1321  10.152.183.88   no       
knative-eventing               active      1  knative-eventing                  0  10.152.183.214  no       
knative-operator               active      1  knative-operator                  0  10.152.183.30   no       
knative-serving                active      1  knative-serving                   0  10.152.183.171  no       

Unit                     Workload  Agent  Address       Ports  Message
istio-ingressgateway/0*  active    idle   10.1.224.93          
istio-pilot/0*           active    idle   10.1.224.86          
knative-eventing/0*      active    idle   10.1.224.109         
knative-operator/0*      active    idle   10.1.224.110         
knative-serving/0*       active    idle   10.1.224.114         

Integration provider     Requirer                          Interface          Type     Message
istio-pilot:istio-pilot  istio-ingressgateway:istio-pilot  k8s-service        regular  
istio-pilot:peers        istio-pilot:peers                 istio_pilot_peers  peer     
``` 

Below is images of the pod `microk8s kubectl get pod *pod* --namespace knative-serving -o jsonpath="{..image}"`
```
docker.io/library/knative-serving-autoscaler:1.16.0 docker.io/library/knative-serving-autoscaler:1.16.0
```

Logs of passed integration tests `tox -vve integration -- --model kubeflow --keep-models`

```

============================================================================================== 7 passed in 978.14s (0:16:18) ==============================================================================================
integration: 980946 I exit 0 (980.30 seconds) /home/pepsiqqq/Projects/knative-operators> pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native --model kubeflow --keep-models tests/test_bundle.py pid=460256 [tox/execute/api.py:294]
  integration: OK (980.46=setup[0.16]+cmd[980.30] seconds)
  congratulations :) (980.66 seconds)
```