### PR TITLE
fix: patch upstream code to set `ReadOnlyRootFilesystem` of `queue-proxy` to `false`

### DIFF
--- a/knative-serving-controller/rockcraft.yaml
+++ b/knative-serving-controller/rockcraft.yaml
@@ -57,6 +57,15 @@ parts:
       - netbase
       - tzdata
     override-build: |
+      # Patch ReadOnlyRootFilesystem in queue.go to create queue-proxy
+      # container with a writable file system.
+      # More details in https://github.com/canonical/knative-rocks/issues/44.
+      # Remove once pebble won't need to always write some state to disk
+      # https://github.com/canonical/pebble/issues/462.
+      sed -i \
+          's#ReadOnlyRootFilesystem:   ptr.Bool(true)#ReadOnlyRootFilesystem:   ptr.Bool(false)#' \
+          pkg/reconciler/revision/resources/queue.go
+
       go mod download
 
       # Build


### PR DESCRIPTION
Closes #44, for details see the issue.

## Testing
1. Deploy knative and istio charms from `latest/edge` and add relations as done in the [tests](https://github.com/canonical/knative-operators/blob/main/tests/test_bundle.py#L64)
2. Pack the rock and import to microk8s registry
3. Set the config in `knative-serving` charm to change the image to the local rock:
```
juju config knative-serving queue_sidecar_image=docker.io/library/knative-serving-queue:1.16.0
```
4. Create a Knative Service using the [yaml](https://github.com/canonical/knative-operators/blob/main/examples/cloudevents-player.yaml) from the test examples
5. Get the yaml of the knative service pod and grep for `readOnlyRootFilesystem`. should be set to `false`:
```
kubectl get po -n knative-test cloudevents-player-00001-deployment-ccdc4b7ff-bc4nr -oyaml | grep readOnlyRootFilesystem
readOnlyRootFilesystem: false
```