### PR TITLE
feat: `knative-eventing-channel-dispatcher` create rocks-automation-ci.yaml

### DIFF
--- a/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
+++ b/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/knative-operators.git
+   
+    replace-image:
+      - file: charms/knative-eventing/src/default-custom-images.json
+        path: imc-dispatcher/dispatcher

--- a/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
+++ b/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
@@ -3,5 +3,4 @@ integrations:
    
     replace-image:
       - file: charms/knative-eventing/src/default-custom-images.json
-        path: |
-          imc-dispatcher/dispatcher
+        path: "imc-dispatcher/dispatcher"

--- a/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
+++ b/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
@@ -3,4 +3,4 @@ integrations:
    
     replace-image:
       - file: charms/knative-eventing/src/default-custom-images.json
-        path: $["foo/bar"]
+        path: $["imc-dispatcher/dispatcher"]

--- a/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
+++ b/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
@@ -3,4 +3,4 @@ integrations:
    
     replace-image:
       - file: charms/knative-eventing/src/default-custom-images.json
-        path: "imc-dispatcher/dispatcher"
+        path: $["foo/bar"]

--- a/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
+++ b/knative-eventing-channel-dispatcher/rock-ci-metadata.yaml
@@ -3,4 +3,5 @@ integrations:
    
     replace-image:
       - file: charms/knative-eventing/src/default-custom-images.json
-        path: imc-dispatcher/dispatcher
+        path: |
+          imc-dispatcher/dispatcher


### PR DESCRIPTION
Closes: https://github.com/canonical/knative-rocks/issues/54

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.

Issue related to service file https://github.com/canonical/kfp-operators/issues/755