### PR TITLE
feat: `knative-eventing-mtping` create rocks-automation-ci.yaml

### DIFF
--- a/knative-eventing-mtping/rock-ci-metadata.yaml
+++ b/knative-eventing-mtping/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/knative-operators.git
+   
+    replace-image:
+      - file: charms/knative-eventing/src/default-custom-images.json
+        path: $["pingsource-mt-adapter/dispatcher"]


### PR DESCRIPTION
Closes: https://github.com/canonical/knative-rocks/issues/58

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.