### PR TITLE
feat: `knative-serving-webhook` create rocks-automation-ci.yaml

### DIFF
--- a/knative-serving-webhook/rock-ci-metadata.yaml
+++ b/knative-serving-webhook/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/knative-operators.git
+   
+    replace-image:
+      - file: charms/knative-serving/src/default-custom-images.json
+        path: webhook


### PR DESCRIPTION
Closes: https://github.com/canonical/knative-rocks/issues/66

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.