### PR TITLE
feat: `knative-eventing-job-sink` create rock-ci-metadata.yaml

### DIFF
--- a/knative-eventing-job-sink/rock-ci-metadata.yaml
+++ b/knative-eventing-job-sink/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/knative-operators.git
+   
+    replace-image:
+      - file: charms/knative-eventing/src/default-custom-images.json
+        path: $["job-sink/job-sink"]


### PR DESCRIPTION
Closes #56 

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.