### PR TITLE
feat: add rock-metadata file for knative-serving-default-domain

### DIFF
--- a/knative-serving-default-domain/rock-ci-metadata.yaml
+++ b/knative-serving-default-domain/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []


### PR DESCRIPTION
Closes: https://github.com/canonical/knative-rocks/issues/64