### PR TITLE
fix(migrate): allow Pebble to shutdown when service exits without errors

### DIFF
--- a/migrate/rockcraft.yaml
+++ b/migrate/rockcraft.yaml
@@ -22,6 +22,7 @@ services:
     override: replace
     command: "/ko-app/migrate [ ]"
     startup: enabled
+    on-success: shutdown
 
 parts:
   security-team-requirement:


### PR DESCRIPTION
This PR adds the `on-success` definition so that when `migrate` service completes and exits with code 0, it is not restarted.

This PR is required to close https://github.com/canonical/knative-operators/issues/334.